### PR TITLE
Fix gesture detection area of backspace key

### DIFF
--- a/lib/src/keyboard.dart
+++ b/lib/src/keyboard.dart
@@ -390,7 +390,8 @@ class _VirtualKeyboardState extends State<VirtualKeyboard> {
               // Cancel event loop
               longPress = false;
             },
-            child: SizedBox(
+            child: Container(
+              color: Colors.transparent,
               height: double.infinity,
               width: double.infinity,
               child: Icon(


### PR DESCRIPTION
So I ran into an issue where the backspace event loop was only triggered when pressing the icon of the key directly. With this small fix it is triggered by long pressing any area of the backspace key.